### PR TITLE
refactor: modernize routing and ui

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -100,7 +100,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
     ],
     redirect: (context, state) {
       final done = prefs.getBool(kOnboardingCompleteKey) ?? false;
-      final inOnboarding = state.subloc == '/onboarding';
+      final inOnboarding = state.matchedLocation == '/onboarding';
       if (!done && !inOnboarding) return '/onboarding';
       if (done && inOnboarding) return '/logs';
       return null;

--- a/lib/onboarding/onboarding_screen.dart
+++ b/lib/onboarding/onboarding_screen.dart
@@ -76,13 +76,17 @@ class _UnitSystemStep extends ConsumerWidget {
           title: Text(strings.unitMetric),
           value: UnitSystem.metric,
           groupValue: current,
-          onChanged: (v) => controller.setUnitSystem(v!),
+          onChanged: (v) {
+            if (v != null) controller.setUnitSystem(v);
+          },
         ),
         RadioListTile<UnitSystem>(
           title: Text(strings.unitImperial),
           value: UnitSystem.imperial,
           groupValue: current,
-          onChanged: (v) => controller.setUnitSystem(v!),
+          onChanged: (v) {
+            if (v != null) controller.setUnitSystem(v);
+          },
         ),
       ],
     );
@@ -103,13 +107,17 @@ class _VitaminsStep extends ConsumerWidget {
           title: Text(strings.vitaminsBucket),
           value: VitaminsMode.generic,
           groupValue: current,
-          onChanged: (v) => controller.setVitaminsMode(v!),
+          onChanged: (v) {
+            if (v != null) controller.setVitaminsMode(v);
+          },
         ),
         RadioListTile<VitaminsMode>(
           title: Text(strings.vitaminsSpecific),
           value: VitaminsMode.specific,
           groupValue: current,
-          onChanged: (v) => controller.setVitaminsMode(v!),
+          onChanged: (v) {
+            if (v != null) controller.setVitaminsMode(v);
+          },
         ),
       ],
     );
@@ -210,19 +218,25 @@ class _ThemeStep extends ConsumerWidget {
           title: Text(strings.themeSystem),
           value: ThemeMode.system,
           groupValue: current,
-          onChanged: (v) => controller.setThemeMode(v!),
+          onChanged: (v) {
+            if (v != null) controller.setThemeMode(v);
+          },
         ),
         RadioListTile<ThemeMode>(
           title: Text(strings.themeLight),
           value: ThemeMode.light,
           groupValue: current,
-          onChanged: (v) => controller.setThemeMode(v!),
+          onChanged: (v) {
+            if (v != null) controller.setThemeMode(v);
+          },
         ),
         RadioListTile<ThemeMode>(
           title: Text(strings.themeDark),
           value: ThemeMode.dark,
           groupValue: current,
-          onChanged: (v) => controller.setThemeMode(v!),
+          onChanged: (v) {
+            if (v != null) controller.setThemeMode(v);
+          },
         ),
       ],
     );

--- a/lib/screens/goal_editor_dialog.dart
+++ b/lib/screens/goal_editor_dialog.dart
@@ -117,13 +117,17 @@ class _GoalEditorDialogState extends ConsumerState<GoalEditorDialog> {
                   title: Text(AppLocalizations.of(context)!.weekly),
                   value: GoalPeriod.week,
                   groupValue: _period,
-                  onChanged: (v) => setState(() => _period = v!),
+                  onChanged: (v) {
+                    if (v != null) setState(() => _period = v);
+                  },
                 ),
                 RadioListTile<GoalPeriod>(
                   title: Text(AppLocalizations.of(context)!.monthly),
                   value: GoalPeriod.month,
                   groupValue: _period,
-                  onChanged: (v) => setState(() => _period = v!),
+                  onChanged: (v) {
+                    if (v != null) setState(() => _period = v);
+                  },
                 ),
               ],
             ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -27,7 +27,9 @@ class SettingsScreen extends ConsumerWidget {
 
               value: UnitSystem.metric,
               groupValue: settings.unitSystem,
-              onChanged: (v) => controller.setUnitSystem(v!),
+              onChanged: (v) {
+                if (v != null) controller.setUnitSystem(v);
+              },
             ),
           ),
           Semantics(
@@ -38,7 +40,9 @@ class SettingsScreen extends ConsumerWidget {
 
               value: UnitSystem.imperial,
               groupValue: settings.unitSystem,
-              onChanged: (v) => controller.setUnitSystem(v!),
+              onChanged: (v) {
+                if (v != null) controller.setUnitSystem(v);
+              },
             ),
           ),
           const Divider(),
@@ -50,7 +54,9 @@ class SettingsScreen extends ConsumerWidget {
 
               value: VitaminsMode.generic,
               groupValue: settings.vitaminsMode,
-              onChanged: (v) => controller.setVitaminsMode(v!),
+              onChanged: (v) {
+                if (v != null) controller.setVitaminsMode(v);
+              },
             ),
           ),
           Semantics(
@@ -60,7 +66,9 @@ class SettingsScreen extends ConsumerWidget {
 
               value: VitaminsMode.specific,
               groupValue: settings.vitaminsMode,
-              onChanged: (v) => controller.setVitaminsMode(v!),
+              onChanged: (v) {
+                if (v != null) controller.setVitaminsMode(v);
+              },
             ),
           ),
           const Divider(),
@@ -72,7 +80,9 @@ class SettingsScreen extends ConsumerWidget {
 
               value: ThemeMode.system,
               groupValue: settings.themeMode,
-              onChanged: (v) => controller.setThemeMode(v!),
+              onChanged: (v) {
+                if (v != null) controller.setThemeMode(v);
+              },
             ),
           ),
           Semantics(
@@ -82,7 +92,9 @@ class SettingsScreen extends ConsumerWidget {
 
               value: ThemeMode.light,
               groupValue: settings.themeMode,
-              onChanged: (v) => controller.setThemeMode(v!),
+              onChanged: (v) {
+                if (v != null) controller.setThemeMode(v);
+              },
             ),
           ),
           Semantics(
@@ -92,7 +104,9 @@ class SettingsScreen extends ConsumerWidget {
 
               value: ThemeMode.dark,
               groupValue: settings.themeMode,
-              onChanged: (v) => controller.setThemeMode(v!),
+              onChanged: (v) {
+                if (v != null) controller.setThemeMode(v);
+              },
             ),
           ),
           const Divider(),

--- a/lib/screens/statistics_screen.dart
+++ b/lib/screens/statistics_screen.dart
@@ -6,9 +6,10 @@ import 'package:intl/intl.dart';
 
 
 import '../data/goal_repository.dart';
+import '../data/local/app_database.dart';
 import 'goal_editor_dialog.dart';
 
-Color _colorForDisposition(GoalDisposition d) {
+Color goalColor(GoalDisposition d) {
   switch (d) {
     case GoalDisposition.good:
       return Colors.green;
@@ -17,6 +18,7 @@ Color _colorForDisposition(GoalDisposition d) {
     case GoalDisposition.bad:
       return Colors.red;
   }
+  return Colors.grey;
 }
 
 class StatisticsScreen extends ConsumerStatefulWidget {
@@ -168,7 +170,7 @@ class _StatisticsScreenState extends ConsumerState<StatisticsScreen>
               if (progress.weeklyDisposition == GoalDisposition.good &&
                   progress.monthlyDisposition != GoalDisposition.good)
                 Text(AppLocalizations.of(context)!.monthlyWarning,
-                    style: TextStyle(color: _colorForDisposition(progress.monthlyDisposition))),
+                    style: TextStyle(color: goalColor(progress.monthlyDisposition))),
               SizedBox(
                 height: 220,
                 child: _MonthlyChart(progress: progress),
@@ -245,7 +247,7 @@ class _WeeklyChart extends StatelessWidget {
             HorizontalRangeAnnotation(
               y1: 0,
               y2: progress.capValue,
-              color: Colors.green.withOpacity(0.2),
+              color: Colors.green.withAlpha(51),
             )
           ],
         ),
@@ -295,7 +297,7 @@ class _MonthlyChart extends StatelessWidget {
             HorizontalRangeAnnotation(
               y1: 0,
               y2: progress.capValue,
-              color: Colors.green.withOpacity(0.2),
+              color: Colors.green.withAlpha(51),
             )
           ],
         ),
@@ -304,7 +306,7 @@ class _MonthlyChart extends StatelessWidget {
             spots: spots,
             isCurved: false,
             barWidth: 3,
-            color: _colorForDisposition(progress.monthlyDisposition),
+            color: goalColor(progress.monthlyDisposition),
             dotData: FlDotData(show: true),
           )
         ],

--- a/lib/widgets/button_styles.dart
+++ b/lib/widgets/button_styles.dart
@@ -8,19 +8,19 @@ class AppButtonStyles {
   static ButtonStyle primary(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
     return ButtonStyle(
-      minimumSize: MaterialStateProperty.all(const Size(64, 48)),
-      backgroundColor: MaterialStateProperty.resolveWith((states) {
-        if (states.contains(MaterialState.disabled)) {
-          return scheme.onSurface.withOpacity(0.12);
+      minimumSize: WidgetStateProperty.all(const Size(64, 48)),
+      backgroundColor: WidgetStateProperty.resolveWith((states) {
+        if (states.contains(WidgetState.disabled)) {
+          return scheme.onSurface.withAlpha(31);
         }
-        if (states.contains(MaterialState.pressed)) {
-          return scheme.primary.withOpacity(0.8);
+        if (states.contains(WidgetState.pressed)) {
+          return scheme.primary.withAlpha(204);
         }
         return scheme.primary;
       }),
-      foregroundColor: MaterialStateProperty.resolveWith((states) {
-        if (states.contains(MaterialState.disabled)) {
-          return scheme.onSurface.withOpacity(0.38);
+      foregroundColor: WidgetStateProperty.resolveWith((states) {
+        if (states.contains(WidgetState.disabled)) {
+          return scheme.onSurface.withAlpha(97);
         }
         return scheme.onPrimary;
       }),


### PR DESCRIPTION
## Summary
- use `matchedLocation` with go_router
- make Radio callbacks null-safe and adopt WidgetStateProperty for buttons
- introduce goalColor helper and replace deprecated withOpacity calls

## Testing
- `dart format lib/app_router.dart lib/onboarding/onboarding_screen.dart lib/screens/goal_editor_dialog.dart lib/screens/settings_screen.dart lib/screens/statistics_screen.dart lib/widgets/button_styles.dart` (fails: command not found)
- `flutter analyze` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a79ddb61f88330b9abef29bbf10835