### PR TITLE
refactor: modernize routing and ui

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.food_app">
+    package="com.example.food_tracker">
     <uses-permission android:name="android.permission.CAMERA" />
-    <application android:label="Food App" android:icon="@mipmap/ic_launcher">
-        <activity android:name="android.app.Activity" />
+    <application
+        android:label="Food Tracker"
+        android:icon="@mipmap/ic_launcher">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/android/app/src/main/kotlin/com/example/food_tracker/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/food_tracker/MainActivity.kt
@@ -1,0 +1,6 @@
+package com.example.food_tracker
+
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity: FlutterActivity() {
+}

--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:food_tracker/l10n/app_localizations.dart';
 
 
 import 'screens/logs_screen.dart';
@@ -100,7 +100,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
     ],
     redirect: (context, state) {
       final done = prefs.getBool(kOnboardingCompleteKey) ?? false;
-      final inOnboarding = state.subloc == '/onboarding';
+      final inOnboarding = state.matchedLocation == '/onboarding';
       if (!done && !inOnboarding) return '/onboarding';
       if (done && inOnboarding) return '/logs';
       return null;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:food_tracker/l10n/app_localizations.dart';
 
 import 'package:shared_preferences/shared_preferences.dart';
 

--- a/lib/onboarding/onboarding_screen.dart
+++ b/lib/onboarding/onboarding_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:food_tracker/l10n/app_localizations.dart';
 import 'package:go_router/go_router.dart';
 
 import '../settings/settings_controller.dart';
@@ -76,13 +76,17 @@ class _UnitSystemStep extends ConsumerWidget {
           title: Text(strings.unitMetric),
           value: UnitSystem.metric,
           groupValue: current,
-          onChanged: (v) => controller.setUnitSystem(v!),
+          onChanged: (v) {
+            if (v != null) controller.setUnitSystem(v);
+          },
         ),
         RadioListTile<UnitSystem>(
           title: Text(strings.unitImperial),
           value: UnitSystem.imperial,
           groupValue: current,
-          onChanged: (v) => controller.setUnitSystem(v!),
+          onChanged: (v) {
+            if (v != null) controller.setUnitSystem(v);
+          },
         ),
       ],
     );
@@ -103,13 +107,17 @@ class _VitaminsStep extends ConsumerWidget {
           title: Text(strings.vitaminsBucket),
           value: VitaminsMode.generic,
           groupValue: current,
-          onChanged: (v) => controller.setVitaminsMode(v!),
+          onChanged: (v) {
+            if (v != null) controller.setVitaminsMode(v);
+          },
         ),
         RadioListTile<VitaminsMode>(
           title: Text(strings.vitaminsSpecific),
           value: VitaminsMode.specific,
           groupValue: current,
-          onChanged: (v) => controller.setVitaminsMode(v!),
+          onChanged: (v) {
+            if (v != null) controller.setVitaminsMode(v);
+          },
         ),
       ],
     );
@@ -210,19 +218,25 @@ class _ThemeStep extends ConsumerWidget {
           title: Text(strings.themeSystem),
           value: ThemeMode.system,
           groupValue: current,
-          onChanged: (v) => controller.setThemeMode(v!),
+          onChanged: (v) {
+            if (v != null) controller.setThemeMode(v);
+          },
         ),
         RadioListTile<ThemeMode>(
           title: Text(strings.themeLight),
           value: ThemeMode.light,
           groupValue: current,
-          onChanged: (v) => controller.setThemeMode(v!),
+          onChanged: (v) {
+            if (v != null) controller.setThemeMode(v);
+          },
         ),
         RadioListTile<ThemeMode>(
           title: Text(strings.themeDark),
           value: ThemeMode.dark,
           groupValue: current,
-          onChanged: (v) => controller.setThemeMode(v!),
+          onChanged: (v) {
+            if (v != null) controller.setThemeMode(v);
+          },
         ),
       ],
     );

--- a/lib/screens/goal_editor_dialog.dart
+++ b/lib/screens/goal_editor_dialog.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:food_tracker/l10n/app_localizations.dart';
 
 import '../data/local/app_database.dart';
 import '../data/goal_repository.dart';
@@ -117,13 +117,17 @@ class _GoalEditorDialogState extends ConsumerState<GoalEditorDialog> {
                   title: Text(AppLocalizations.of(context)!.weekly),
                   value: GoalPeriod.week,
                   groupValue: _period,
-                  onChanged: (v) => setState(() => _period = v!),
+                  onChanged: (v) {
+                    if (v != null) setState(() => _period = v);
+                  },
                 ),
                 RadioListTile<GoalPeriod>(
                   title: Text(AppLocalizations.of(context)!.monthly),
                   value: GoalPeriod.month,
                   groupValue: _period,
-                  onChanged: (v) => setState(() => _period = v!),
+                  onChanged: (v) {
+                    if (v != null) setState(() => _period = v);
+                  },
                 ),
               ],
             ),

--- a/lib/screens/log_entry_dialog.dart
+++ b/lib/screens/log_entry_dialog.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:food_tracker/l10n/app_localizations.dart';
 
 import '../data/log_repository.dart';
 import '../widgets/button_styles.dart';

--- a/lib/screens/logs_screen.dart
+++ b/lib/screens/logs_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:table_calendar/table_calendar.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:food_tracker/l10n/app_localizations.dart';
 
 import '../data/log_repository.dart';
 import '../widgets/undo_snackbar.dart';

--- a/lib/screens/meal_form_view.dart
+++ b/lib/screens/meal_form_view.dart
@@ -6,7 +6,7 @@ import '../data/product_repository.dart';
 import '../data/meal_repository.dart';
 import '../data/conversion_service.dart';
 import '../data/local/app_database.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:food_tracker/l10n/app_localizations.dart';
 
 
 class MealItemInput {

--- a/lib/screens/meals_screen.dart
+++ b/lib/screens/meals_screen.dart
@@ -5,7 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../data/meal_repository.dart';
 import '../widgets/undo_snackbar.dart';
 import 'meal_form_view.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:food_tracker/l10n/app_localizations.dart';
 
 
 class MealsScreen extends ConsumerStatefulWidget {

--- a/lib/screens/product_form_view.dart
+++ b/lib/screens/product_form_view.dart
@@ -6,7 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../data/local/app_database.dart';
 import '../data/product_repository.dart';
 import '../widgets/button_styles.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:food_tracker/l10n/app_localizations.dart';
 
 
 double _roundTo(double value, int places) {

--- a/lib/screens/products_screen.dart
+++ b/lib/screens/products_screen.dart
@@ -4,7 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../data/product_repository.dart';
 import '../widgets/undo_snackbar.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:food_tracker/l10n/app_localizations.dart';
 
 
 /// Displays the list of products with support for adding, editing and

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../settings/settings_controller.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:food_tracker/l10n/app_localizations.dart';
 import '../settings/debug_sample_data.dart';
 
 
@@ -27,7 +27,9 @@ class SettingsScreen extends ConsumerWidget {
 
               value: UnitSystem.metric,
               groupValue: settings.unitSystem,
-              onChanged: (v) => controller.setUnitSystem(v!),
+              onChanged: (v) {
+                if (v != null) controller.setUnitSystem(v);
+              },
             ),
           ),
           Semantics(
@@ -38,7 +40,9 @@ class SettingsScreen extends ConsumerWidget {
 
               value: UnitSystem.imperial,
               groupValue: settings.unitSystem,
-              onChanged: (v) => controller.setUnitSystem(v!),
+              onChanged: (v) {
+                if (v != null) controller.setUnitSystem(v);
+              },
             ),
           ),
           const Divider(),
@@ -50,7 +54,9 @@ class SettingsScreen extends ConsumerWidget {
 
               value: VitaminsMode.generic,
               groupValue: settings.vitaminsMode,
-              onChanged: (v) => controller.setVitaminsMode(v!),
+              onChanged: (v) {
+                if (v != null) controller.setVitaminsMode(v);
+              },
             ),
           ),
           Semantics(
@@ -60,7 +66,9 @@ class SettingsScreen extends ConsumerWidget {
 
               value: VitaminsMode.specific,
               groupValue: settings.vitaminsMode,
-              onChanged: (v) => controller.setVitaminsMode(v!),
+              onChanged: (v) {
+                if (v != null) controller.setVitaminsMode(v);
+              },
             ),
           ),
           const Divider(),
@@ -72,7 +80,9 @@ class SettingsScreen extends ConsumerWidget {
 
               value: ThemeMode.system,
               groupValue: settings.themeMode,
-              onChanged: (v) => controller.setThemeMode(v!),
+              onChanged: (v) {
+                if (v != null) controller.setThemeMode(v);
+              },
             ),
           ),
           Semantics(
@@ -82,7 +92,9 @@ class SettingsScreen extends ConsumerWidget {
 
               value: ThemeMode.light,
               groupValue: settings.themeMode,
-              onChanged: (v) => controller.setThemeMode(v!),
+              onChanged: (v) {
+                if (v != null) controller.setThemeMode(v);
+              },
             ),
           ),
           Semantics(
@@ -92,7 +104,9 @@ class SettingsScreen extends ConsumerWidget {
 
               value: ThemeMode.dark,
               groupValue: settings.themeMode,
-              onChanged: (v) => controller.setThemeMode(v!),
+              onChanged: (v) {
+                if (v != null) controller.setThemeMode(v);
+              },
             ),
           ),
           const Divider(),

--- a/lib/screens/statistics_screen.dart
+++ b/lib/screens/statistics_screen.dart
@@ -1,14 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fl_chart/fl_chart.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:food_tracker/l10n/app_localizations.dart';
 import 'package:intl/intl.dart';
 
 
 import '../data/goal_repository.dart';
+import '../data/local/app_database.dart';
 import 'goal_editor_dialog.dart';
 
-Color _colorForDisposition(GoalDisposition d) {
+Color goalColor(GoalDisposition d) {
   switch (d) {
     case GoalDisposition.good:
       return Colors.green;
@@ -17,6 +18,7 @@ Color _colorForDisposition(GoalDisposition d) {
     case GoalDisposition.bad:
       return Colors.red;
   }
+  return Colors.grey;
 }
 
 class StatisticsScreen extends ConsumerStatefulWidget {
@@ -168,7 +170,7 @@ class _StatisticsScreenState extends ConsumerState<StatisticsScreen>
               if (progress.weeklyDisposition == GoalDisposition.good &&
                   progress.monthlyDisposition != GoalDisposition.good)
                 Text(AppLocalizations.of(context)!.monthlyWarning,
-                    style: TextStyle(color: _colorForDisposition(progress.monthlyDisposition))),
+                    style: TextStyle(color: goalColor(progress.monthlyDisposition))),
               SizedBox(
                 height: 220,
                 child: _MonthlyChart(progress: progress),
@@ -245,7 +247,7 @@ class _WeeklyChart extends StatelessWidget {
             HorizontalRangeAnnotation(
               y1: 0,
               y2: progress.capValue,
-              color: Colors.green.withOpacity(0.2),
+              color: Colors.green.withAlpha(51),
             )
           ],
         ),
@@ -295,7 +297,7 @@ class _MonthlyChart extends StatelessWidget {
             HorizontalRangeAnnotation(
               y1: 0,
               y2: progress.capValue,
-              color: Colors.green.withOpacity(0.2),
+              color: Colors.green.withAlpha(51),
             )
           ],
         ),
@@ -304,7 +306,7 @@ class _MonthlyChart extends StatelessWidget {
             spots: spots,
             isCurved: false,
             barWidth: 3,
-            color: _colorForDisposition(progress.monthlyDisposition),
+            color: goalColor(progress.monthlyDisposition),
             dotData: FlDotData(show: true),
           )
         ],

--- a/lib/widgets/button_styles.dart
+++ b/lib/widgets/button_styles.dart
@@ -8,19 +8,19 @@ class AppButtonStyles {
   static ButtonStyle primary(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
     return ButtonStyle(
-      minimumSize: MaterialStateProperty.all(const Size(64, 48)),
-      backgroundColor: MaterialStateProperty.resolveWith((states) {
-        if (states.contains(MaterialState.disabled)) {
-          return scheme.onSurface.withOpacity(0.12);
+      minimumSize: WidgetStateProperty.all(const Size(64, 48)),
+      backgroundColor: WidgetStateProperty.resolveWith((states) {
+        if (states.contains(WidgetState.disabled)) {
+          return scheme.onSurface.withAlpha(31);
         }
-        if (states.contains(MaterialState.pressed)) {
-          return scheme.primary.withOpacity(0.8);
+        if (states.contains(WidgetState.pressed)) {
+          return scheme.primary.withAlpha(204);
         }
         return scheme.primary;
       }),
-      foregroundColor: MaterialStateProperty.resolveWith((states) {
-        if (states.contains(MaterialState.disabled)) {
-          return scheme.onSurface.withOpacity(0.38);
+      foregroundColor: WidgetStateProperty.resolveWith((states) {
+        if (states.contains(WidgetState.disabled)) {
+          return scheme.onSurface.withAlpha(97);
         }
         return scheme.onPrimary;
       }),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,5 +26,5 @@ dev_dependencies:
   build_runner: ^2.4.6
 
 flutter:
-  generate: true
   uses-material-design: true
+  generate: true


### PR DESCRIPTION
## Summary
- use `matchedLocation` with go_router
- make Radio callbacks null-safe and adopt WidgetStateProperty for buttons
- introduce goalColor helper and replace deprecated withOpacity calls
- update localization imports to project `l10n` output
- clean up Android manifest and add `MainActivity` placeholder
- de-duplicate `flutter: generate` config in pubspec

## Testing
- `apt-get update`
- `apt-get install -y dart` (fails: Unable to locate package dart)
- `apt-get install -y flutter` (fails: Unable to locate package flutter)
- `dart format android/app/src/main/AndroidManifest.xml lib/app_router.dart lib/main.dart lib/onboarding/onboarding_screen.dart lib/screens/goal_editor_dialog.dart lib/screens/log_entry_dialog.dart lib/screens/logs_screen.dart lib/screens/meal_form_view.dart lib/screens/meals_screen.dart lib/screens/product_form_view.dart lib/screens/products_screen.dart lib/screens/settings_screen.dart lib/screens/statistics_screen.dart pubspec.yaml` (fails: command not found)
- `flutter analyze` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a79ddb61f88330b9abef29bbf10835