### PR TITLE
Update intl dependency version to match SDK

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   shared_preferences: ^2.2.2
   table_calendar: ^3.0.9
   fl_chart: ^1.0.0
-  intl: ^0.18.1
+  intl: ^0.20.2
 
 dev_dependencies:
   flutter_lints: ^3.0.0


### PR DESCRIPTION
## Summary
- upgrade `intl` to ^0.20.2 to align with `flutter_localizations`

## Testing
- `flutter pub get` *(fails: prompt hang but dependencies fetched)*
- `flutter analyze` *(failed: tool building stalled)*

------
https://chatgpt.com/codex/tasks/task_e_68aa16a2b1688330a8b948cc29e061a3