### PR TITLE
Disable ABI splits and specify NDK ABI filters

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,0 +1,12 @@
+android {
+    splits {
+        abi {
+            enable false
+        }
+    }
+    defaultConfig {
+        ndk {
+            abiFilters "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- disable ABI splits in `android/app/build.gradle`
- specify NDK ABI filters to include all main ABIs

## Testing
- `npm test`
- `./gradlew assembleDebug` *(fails: No such file or directory)*
- `aapt dump badging android/app/build/outputs/apk/debug/app-debug.apk` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b39b71bb0083308f80d1f97945c1bd